### PR TITLE
Conditially append existing TEXMFHOME in devshell

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -87,7 +87,7 @@ pkgs.stdenv.mkDerivation {
     pkgs.which
   ];
   shellHook = ''
-    export TEXMFHOME=$(pwd):$TEXMFHOME
+    export TEXMFHOME=$(pwd)''${TEXMFHOME:+:}''${TEXMFHOME:-}
   '';
 
   buildPhase = ''


### PR DESCRIPTION
Hello!

I don't have a globally-defined `$TEXTMFHOME` variable in my brand-new installation, so this line in the shell hook:
```
export TEXMFHOME=$(pwd):$TEXMFHOME
```

Is currently failing with:
```
/home/agustin/.config/direnv/lib/hm-nix-direnv.sh:2198: TEXMFHOME: unbound variable
```

Not sure if there's a mismatch between different flavors of direnv using bash in strict vs. non-strict mode, but I thought I would open this PR to make sure that `:$TEXMFHOME` is not added if the variable is unbound.
