### PR TITLE
Fix typo on design document

### DIFF
--- a/design/interactions.tex
+++ b/design/interactions.tex
@@ -2,7 +2,7 @@ We provide a preliminary discussion of the interactions of Peras with Mithril\fo
 
 \section{Mithril}\label{sec:mithril}
 
-Mithril is a protocol for generating stake-based threshold multi-signatures for certain entities related the Cardano blockchain, for example the stake distribution, the node database or even individual transactions.
+Mithril is a protocol for generating stake-based threshold multi-signatures for certain entities related to the Cardano blockchain, for example the stake distribution, the node database or even individual transactions.
 
 \subsection{Mithril certificates for more recent state}
 


### PR DESCRIPTION
The word "to" seem to be missing in a sentence.