### PR TITLE
Add docker builder for demo derivation

### DIFF
--- a/demo/default.nix
+++ b/demo/default.nix
@@ -62,6 +62,12 @@ let
     in
     patchedProject.hsPkgs.cardano-node.components.exes.cardano-node;
 
+  # Template testnet files
+  testnet = pkgs.runCommandLocal "testnet" { } ''
+    mkdir -p $out
+    cp -r ${./env}/. $out
+  '';
+
 in
 pkgs.writeShellApplication {
   name = "demo";
@@ -69,11 +75,13 @@ pkgs.writeShellApplication {
     cardano-node
     toxiproxy
     jq
+    coreutils
+    procps
   ];
   runtimeEnv = {
     CARDANO_NODE = "${cardano-node}/bin/cardano-node";
     STATIC_FILES = "${deps.ouroboros-consensus}/static";
-    TESTNET_ENV = ./env;
+    TESTNET_ENV = "${testnet}";
   };
   text = builtins.readFile ./launch.sh;
 }

--- a/demo/docker.nix
+++ b/demo/docker.nix
@@ -1,0 +1,11 @@
+{ pkgs, demo }:
+pkgs.dockerTools.buildImage {
+  name = "cardano-peras-demo";
+  tag = "latest";
+  copyToRoot = [ demo ];
+  runAsRoot = ''
+    mkdir -p ./tmp
+    chmod 777 ./tmp
+  '';
+  config.Cmd = [ "${demo}/bin/demo" ];
+}

--- a/flake.nix
+++ b/flake.nix
@@ -21,9 +21,10 @@
         pkgs = import inputs.nixpkgs { inherit system; };
       in
       {
-        packages = {
+        packages = rec {
           default = import ./default.nix { inherit pkgs; };
           demo = import ./demo { inherit pkgs system; };
+          demo-docker = import ./demo/docker.nix { inherit pkgs demo; };
         };
         devShells.default = import ./default.nix { inherit pkgs; };
       }


### PR DESCRIPTION
This PR adds a simple Nix derivation to build a `cardano-peras-demo:latest` Docker image with the same contents as `.#demo`.

For this to work in the generated image, I had to tweak `.#demo` slightly to include some missing deps and to make sure we copy the testnet template environment into the image and don't rely on a transitive store path.

To try it locally, run:

```
$ docker load < $(nix build .#demo-docker --print-out-paths)
$ docker run --rm -it cardano-peras-demo
```

Additionally, I manually pushed this image to ghcr.io, so here's a oneliner for people without Nix:

```
$ docker run -it --rm --network=host ghcr.io/tweag/cardano-peras/cardano-peras-demo
```
